### PR TITLE
departure time is optional

### DIFF
--- a/app/src/utils/formValidationHandler.ts
+++ b/app/src/utils/formValidationHandler.ts
@@ -23,14 +23,6 @@ export const formValidationHandler = () => {
             return false;
         }
 
-        if (!departureTime) {
-            eventBus.publish(Messages.FORM_ERROR, {
-                field: "departureTime",
-                message: "Bitte Abfahrtszeit angeben!"
-            });
-            return false;
-        }
-
         return true;
     };
 


### PR DESCRIPTION
The departure time is optional in the Google Maps API. And the date picker automatically fills in a date, so it's probably impossible to have no departure date.